### PR TITLE
`flag.Lookup(...)' never returns nil, so use the `isUdp' variable instead.

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ func main() {
 		os.Exit(1)
 	}
 	log.Println("Source port:", sourcePort)
-	if flag.Lookup("u") != nil {
+	if isUdp {
 		log.Println("Protocol:", "udp")
 		isUdp = true
 	} else {


### PR DESCRIPTION
`flag.Lookup(...)' never returns nil, so use the `isUdp' variable instead.


Fixes broken functionality of defaulting to TCP.  Existing code in master defaults to UDP.

---

BTW - Thank you for this nifty tool!