### PR TITLE
Fix handling of `-u` flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,9 +149,8 @@ func main() {
 		os.Exit(1)
 	}
 	log.Println("Source port:", sourcePort)
-	if flag.Lookup("u") != nil {
+	if isUdp {
 		log.Println("Protocol:", "udp")
-		isUdp = true
 	} else {
 		log.Println("Protocol:", "tcp")
 	}


### PR DESCRIPTION
This `flag.Lookup` never returns nil (at least on my machine), so it was impossible to select TCP